### PR TITLE
Fix: Update Next.js export configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  // Other configurations can be added here if needed
+};
+
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nagatani.github.io",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "export": "next export",
     "typecheck": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
The `next export` command has been removed in Next.js 15.3.3. This commit updates the configuration to use `output: 'export'` in `next.config.js` and removes the `export` script from `package.json`.

The `next.config.js` file was created and configured to use CommonJS syntax as `package.json` does not specify `"type": "module"`.