### PR TITLE
Fix: Remove npm run export from GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Build Next.js app
         run: npm run build
 
-      - name: Export Next.js app
-        run: npm run export
-
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
The `npm run export` command was removed from `package.json` in a previous commit. This commit updates the GitHub Actions workflow to remove the corresponding step. The `npm run build` command now handles the export process automatically.